### PR TITLE
Add links to tutorials that use R to work with BEAST2

### DIFF
--- a/tutorials/index.html
+++ b/tutorials/index.html
@@ -29,6 +29,13 @@ These tutorials use the graphical applications of BEAST to perform analyses usin
 <li><a href="https://taming-the-beast.org/tutorials/NS-tutorial/NS-tutorial.pdf">Model selection with nested sampling</a>
 </ul>
 <!--li><a class="external text" href="http://web.archive.org/web/20151222215106/https://beast-classic.googlecode.com/files/Phylogeographyv2.0.pdf" rel="nofollow">Continuous phylogeography on a plane (Version 2.0) (deprecated)</a></li-->
+<h3><span id="R tutorials" class="mw-headline">R tutorials </span></h3>
+These tutorials use the R programming language to work with BEAST2.
+<ul>
+<li><a href="https://ropensci.org/blog/2020/01/28/babette">rOpenSci tutorial</a></li>
+<li><a href="https://methodsblog.com/2018/06/25/babette-beast2">Tutorial at BES Methods</a></li>
+<li><a href="https://github.com/richelbilderbeek/babette_examples">many examples how to call BEAST2 from R, with BEAUti screenshots for comparison</a></li>
+</ul>
 <h3><span id="Manuals" class="mw-headline">Manuals </span></h3>
 <ul>
 <li><a class="external text" href="https://github.com/BEAST2-Dev/SNAPP/releases/download/v1.2.0/SNAPP.pdf" rel="nofollow">A rough guide to SNAPP</a></li>


### PR DESCRIPTION
For an [rOpenSci review](https://github.com/ropensci/software-review/issues/360) it was suggested to add one or more links to `babette` on the BEAST2 website, as this will be the first place people will go to use BEAST2. I picked the most natural place to put these links, but I am open to put these in superior spots.